### PR TITLE
fix issue#10 无法生成markdown 图片链接

### DIFF
--- a/src/uploader.ts
+++ b/src/uploader.ts
@@ -47,7 +47,7 @@ export class PicGoUploader {
       return {
         code: 0,
         msg: "success",
-        data: data.result[0],
+        data: typeof data.result == "string" ? data.result : data.result[0],
       };
     }
   }
@@ -121,6 +121,7 @@ export class PicGoCoreUploader {
     const res = await this.exec(command);
     return res;
   }
+
   async exec(command: string) {
     let { stdout } = await exec(command);
     const res = await streamToString(stdout);


### PR DESCRIPTION
issue#10
在使用一些特殊的图床时，PicGo返回的data.result是一个字符串(图床url)，而非一个数组。 这导致image auto plugin在使用data.result[0]获取图片url时候，获取不到正确的地址，从而没办法生成markdown的image link，导致无法正确显示图片