### PR TITLE
fix: resolve subdirectory-relative image paths correctly in "Upload all"

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -319,8 +319,11 @@ export default class imageAutoUploadPlugin extends Plugin {
           file = filePathMap[uri];
         }
 
-        // 相对路径
-        if ((!file && uri.startsWith("./")) || uri.startsWith("../")) {
+        // 相对路径：./xxx、../xxx 或裸子目录（如 __attachments__/foo.png）
+        // 只要不是 / 开头的绝对路径，都先尝试相对于当前文档目录解析；
+        // 命中后即可跳过下面的 basename 全 vault 搜索，避免把同名不同目录
+        // 的图片错误匹配。
+        if (!file && !uri.startsWith("/")) {
           const filePath = normalizePath(
             resolve(dirname(activeFile.path), uri)
           );
@@ -328,7 +331,7 @@ export default class imageAutoUploadPlugin extends Plugin {
           file = filePathMap[filePath];
         }
 
-        // 尽可能短路径
+        // 兜底：按 basename 搜整个 vault（可能匹配到同名但不同目录的文件）
         if (!file) {
           file = fileMap[fileName];
         }


### PR DESCRIPTION
## Summary

When running "Upload all images" on a note whose images use relative paths like `![](__attachments__/page_001.png)`, the plugin may upload a wrong same-named image from another folder in the vault.

## Root cause

In `uploadAllFile`, the relative-path branch only fires for paths starting with `./` or `../`:

```ts
if ((!file && uri.startsWith("./")) || uri.startsWith("../")) {
```

A bare subdirectory-relative path (e.g. `__attachments__/page_001.png`), which is a perfectly valid Markdown relative path, falls through to the basename-only fallback (`fileMap[fileName]`) and matches the first same-named file anywhere in the vault — often not the intended one.

## Fix

Resolve any non-absolute, non-http path relative to the active file's directory first. Basename search is kept as a last-resort fallback, preserving existing behavior for bare filenames.

## Test plan

- [x] Note at `A/note.md` with `![](__attachments__/foo.png)`, and another `foo.png` existing elsewhere in the vault → now correctly uploads `A/__attachments__/foo.png`
- [x] Existing behavior for `./xxx`, `../xxx`, and bare `foo.png` (basename fallback) preserved
- [x] `pnpm typecheck` passes